### PR TITLE
Update red science internal name for 0.17.x

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,6 +1,6 @@
 -- The items we don't touch so early game is still possible even when starting without items.
 local blacklist = {
-	["science-pack-1"] = true,
+	["automation-science-pack"] = true,
 	["assembling-machine-1"] = true,
 	["assembling-machine-2"] = true,
 	["boiler"] = true,


### PR DESCRIPTION
In Factorio 0.17.x, science-pack-1 (aka Red Science) changed to automation-science-pack.
Update the blacklist so players can handcraft this science pack.