### PR TITLE
Add compatibility with brevven's Aluminum mod

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -54,7 +54,7 @@ local blacklist = {
 	["apm_assembling_machine_0"] = true,
 	["apm_industrial_science_pack"] = true,
 	["apm_lab_0"] = true,
-  -- Krastorio 2
+	-- Krastorio 2
 	["automation-core"] = true,
 }
 

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -56,6 +56,8 @@ local blacklist = {
 	["apm_lab_0"] = true,
 	-- Krastorio 2
 	["automation-core"] = true,
+	-- BZ Aluminum
+	["aluminum-cable"] = true,
 }
 
 -- Patch all recipes to be advanced crafting.


### PR DESCRIPTION
If neither Krastorio 2 nor AAI Industry are installed, aluminum cables are required to craft the offshore pump, so locking them behind assembling machines deadlocks the early game unless you have another means of generating electricity.